### PR TITLE
NCIATWP-10060 - skip CSV header row in group/batch file import

### DIFF
--- a/client-next/src/components/DataBox/GroupBatchModal.tsx
+++ b/client-next/src/components/DataBox/GroupBatchModal.tsx
@@ -101,6 +101,7 @@ export default function GroupBatchModal({
       complete: (results) => {
         const rows = (results.data as string[][])
           .filter((row) => row.length >= 2)
+          .filter((row, i) => i > 0 || !["gsm", "group", "batch"].includes(row[0]?.trim().toLowerCase()))
           .map((row) => ({
             gsm: row[0]?.trim() || "",
             group: row[1]?.trim() || "",

--- a/client-next/src/components/DataBox/GroupBatchModal.tsx
+++ b/client-next/src/components/DataBox/GroupBatchModal.tsx
@@ -96,17 +96,15 @@ export default function GroupBatchModal({
     if (!file) return;
 
     Papa.parse(file, {
-      header: false,
+      header: true,
       skipEmptyLines: true,
+      transformHeader: (h: string) => h.trim().toLowerCase(),
       complete: (results) => {
-        const rows = (results.data as string[][])
-          .filter((row) => row.length >= 2)
-          .filter((row, i) => i > 0 || !["gsm", "group", "batch"].includes(row[0]?.trim().toLowerCase()))
-          .map((row) => ({
-            gsm: row[0]?.trim() || "",
-            group: row[1]?.trim() || "",
-            batch: row[2]?.trim() || "",
-          }));
+        const rows = (results.data as Record<string, string>[]).map((row) => ({
+          gsm: row.gsm?.trim() || "",
+          group: row.group?.trim() || "",
+          batch: row.batch?.trim() || "",
+        }));
 
         const error = store.importGroupsCsv(rows);
         if (error) {


### PR DESCRIPTION
[NCIATWP-10060](https://tracker.nci.nih.gov/browse/NCIATWP-10060)

- Skip CSV header row when importing Group/Batch file. 
- The parser now detects if the first row matches expected column names (gsm/group/batch) and skips it.