### PR TITLE
NCIATWP-9993 - add instant CSS tooltips to Reset buttons

### DIFF
--- a/client-next/src/app/analysis/page.tsx
+++ b/client-next/src/app/analysis/page.tsx
@@ -296,7 +296,7 @@ export default function Analysis() {
                   {geoMutation.isPending && <span className="spinner-border spinner-border-sm me-1" role="status" />}
                   Load
                 </button>
-                <button className="btn btn-nci-primary w-100 mt-2" onClick={handleReset} disabled={isLoading}>Reset</button>
+                <button className="btn btn-nci-primary w-100 mt-2" onClick={handleReset} disabled={isLoading} data-tooltip="Reset to start a new GEO Analysis">Reset</button>
               </div>
             ) : (
               <div key="cel-inputs">
@@ -336,7 +336,7 @@ export default function Analysis() {
                     {celMutation.isPending && <span className="spinner-border spinner-border-sm me-1" role="status" />}
                     Load
                   </button>
-                  <button className="btn btn-nci-primary flex-fill" onClick={handleReset} disabled={isLoading}>Reset</button>
+                  <button className="btn btn-nci-primary flex-fill" onClick={handleReset} disabled={isLoading} data-tooltip="Reset to start a new CEL File Analysis">Reset</button>
                 </div>
               </div>
             )}
@@ -441,7 +441,7 @@ export default function Analysis() {
           {/* Run / Reset buttons (outside sub-boxes) */}
           <div className="mx-2 mb-2">
             <button className="btn btn-nci-primary w-100 mb-2" disabled={!store.dataLoaded || isLoading || store.disableContrast} onClick={handleRunContrast}>Run Contrast</button>
-            <button className="btn btn-nci-primary w-100" onClick={() => { store.resetContrast(); setContrastError(""); setPanelCollapsed(false); }} disabled={isLoading}>Reset</button>
+            <button className="btn btn-nci-primary w-100" onClick={() => { store.resetContrast(); setContrastError(""); setPanelCollapsed(false); }} disabled={isLoading} data-tooltip="Reset to start a new contrast analysis">Reset</button>
             {contrastError && (
               <p style={{ color: "#b22222", fontSize: "0.85rem" }} className="mt-1 mb-0">{contrastError}</p>
             )}

--- a/client-next/src/app/globals.css
+++ b/client-next/src/app/globals.css
@@ -396,6 +396,39 @@ body {
   cursor: default;
 }
 
+[data-tooltip] {
+  position: relative;
+}
+[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  margin-left: 10px;
+  background: #fff;
+  color: #000;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  z-index: 1000;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+[data-tooltip]:hover::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
+  margin-left: -2px;
+  border: 6px solid transparent;
+  border-right-color: #000;
+  z-index: 1001;
+  pointer-events: none;
+}
+
 .cell-tooltip-popup {
   position: fixed;
   background: #fff;


### PR DESCRIPTION
[NCIATWP-9993](https://tracker.nci.nih.gov/browse/NCIATWP-9993)

- Add instant CSS tooltips to all three Reset buttons: GEO reset, CEL File reset, and contrast reset. Includes tooltip for CEL File panel not present in Prod.