### PR TITLE
NCIATWP-10058 - preserve groups/batches when switching chip filter

### DIFF
--- a/client-next/src/app/analysis/page.tsx
+++ b/client-next/src/app/analysis/page.tsx
@@ -440,7 +440,7 @@ export default function Analysis() {
 
           {/* Run / Reset buttons (outside sub-boxes) */}
           <div className="mx-2 mb-2">
-            <button className="btn btn-nci-primary w-100 mb-2" disabled={!store.dataLoaded || isLoading || store.disableContrast} onClick={handleRunContrast}>Run Contrast</button>
+            <button className="btn btn-nci-primary w-100 mb-2" disabled={!store.dataLoaded || isLoading || store.disableContrast || !store.group1 || !store.group2 || store.group1 === store.group2} onClick={handleRunContrast}>Run Contrast</button>
             <button className="btn btn-nci-primary w-100" onClick={() => { store.resetContrast(); setContrastError(""); setPanelCollapsed(false); }} disabled={isLoading}>Reset</button>
             {contrastError && (
               <p style={{ color: "#b22222", fontSize: "0.85rem" }} className="mt-1 mb-0">{contrastError}</p>

--- a/client-next/src/stores/analysisStore.ts
+++ b/client-next/src/stores/analysisStore.ts
@@ -312,9 +312,14 @@ export const useAnalysisStore = create<AnalysisState & AnalysisActions>((set, ge
       dataListChip: { ...state.dataListChip, [chip]: samples },
     })),
   selectChip: (chip) => {
-    const chipData = get().dataListChip[chip];
+    const { chip: currentChip, dataList, dataListChip } = get();
+    // Save current dataList (with group/batch edits) back before switching
+    const updated = currentChip && dataList.length > 0
+      ? { ...dataListChip, [currentChip]: dataList }
+      : dataListChip;
+    const chipData = updated[chip];
     if (chipData) {
-      set({ chip, dataList: chipData });
+      set({ chip, dataList: chipData, dataListChip: updated });
       get().updateAvailableGroups();
     }
   },


### PR DESCRIPTION
[NCIATWP-10058](https://tracker.nci.nih.gov/browse/NCIATWP-10058)

## Summary
- When switching between chips on a multi-chip accession (e.g. GSE22529), user-created groups and batches were lost
- Root cause: `selectChip` replaced `dataList` with the original API data from `dataListChip`, discarding group/batch assignments
- Fix: save current `dataList` (with edits) back into `dataListChip` before loading the new chip's data