### PR TITLE
NCIATWP-9996 - disable Run Contrast when groups are not selected or are the same

### DIFF
--- a/client-next/src/app/analysis/page.tsx
+++ b/client-next/src/app/analysis/page.tsx
@@ -440,7 +440,7 @@ export default function Analysis() {
 
           {/* Run / Reset buttons (outside sub-boxes) */}
           <div className="mx-2 mb-2">
-            <button className="btn btn-nci-primary w-100 mb-2" disabled={!store.dataLoaded || isLoading || store.disableContrast} onClick={handleRunContrast}>Run Contrast</button>
+            <button className="btn btn-nci-primary w-100 mb-2" disabled={!store.dataLoaded || isLoading || store.disableContrast || !store.group1 || !store.group2 || store.group1 === store.group2} onClick={handleRunContrast}>Run Contrast</button>
             <button className="btn btn-nci-primary w-100" onClick={() => { store.resetContrast(); setContrastError(""); setPanelCollapsed(false); }} disabled={isLoading}>Reset</button>
             {contrastError && (
               <p style={{ color: "#b22222", fontSize: "0.85rem" }} className="mt-1 mb-0">{contrastError}</p>


### PR DESCRIPTION
[NCIATWP-9996](https://tracker.nci.nih.gov/browse/NCIATWP-9996)

## Summary
- Run Contrast button now stays disabled until both Group 1 and Group 2 are selected (AC #7)
- Run Contrast button stays disabled when the same group is selected for both, matching Prod behavior
- Linked bugs NCIATWP-10058 and NCIATWP-10061 were fixed in prior PRs
- If Merged https://github.com/CBIIT/nci-webtools-ccr-microarray/pull/163 FIRST then redirect this PR to cdk
- Or merge this PR first and then https://github.com/CBIIT/nci-webtools-ccr-microarray/pull/163 
