### PR TITLE
NCIATWP-9992 - adjust Help page heading hierarchy and styling to match Prod

### DIFF
--- a/client-next/src/app/globals.css
+++ b/client-next/src/app/globals.css
@@ -20,21 +20,25 @@ body {
 .content-board {
   background: #fff;
   box-shadow: 0px 1px 1px 1px #ccc;
-  padding: 2.5rem;
+  padding: 1.5rem 2.5rem 2.5rem;
 }
 
 .content-board h1 {
   color: #2971a5;
-  font-size: 1.5rem;
+  font-size: 2rem;
   line-height: 45px;
   border-bottom: 2px solid #eeeef1;
   margin-top: 1rem;
   padding-bottom: 0.25rem;
 }
 
+.content-board > h2:first-child {
+  margin-top: 0;
+}
+
 .content-board h2 {
   color: #2971a5;
-  font-size: 1.3rem;
+  font-size: 1.75rem;
   line-height: 45px;
   border-bottom: 2px solid #eeeef1;
   margin-top: 1rem;
@@ -43,11 +47,18 @@ body {
 
 .content-board h3 {
   color: #2971a5;
-  font-size: 1.1rem;
+  font-size: 1.5rem;
   line-height: 45px;
   border-bottom: 2px solid #eeeef1;
   margin-top: 1rem;
   padding-bottom: 0.25rem;
+}
+
+.content-board h4 {
+  color: #000;
+  font-size: 1.1rem;
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
 }
 
 .content-board video {

--- a/client-next/src/app/help/page.tsx
+++ b/client-next/src/app/help/page.tsx
@@ -2,7 +2,7 @@
 export default function Help() {
   return (
     <section className="content-board">
-      <h1>Microarrays</h1>
+      <h2>Microarrays</h2>
       <p>
         MicroArray Analysis Pipeline (MAAPster) is a comprehensive web tool designed by the CCR
         Collaborative Bioinformatics Resource (CCBR) that performs transcriptome analysis of
@@ -17,7 +17,7 @@ export default function Help() {
         GSEA analysis.
       </p>
 
-      <h2>Input</h2>
+      <h3>Input</h3>
       <p>There are 2 input options:</p>
       <ol>
         <li>
@@ -53,7 +53,7 @@ export default function Help() {
         </li>
       </ol>
 
-      <h2>Human</h2>
+      <h3>Human</h3>
       <ul>
         <li>Human Genome U133 Plus 2.0 Array</li>
         <li>GeneChip™ Human Genome U133A Array</li>
@@ -73,7 +73,7 @@ export default function Help() {
         <li>Clariom™ D Assay, human</li>
       </ul>
 
-      <h2>Mouse</h2>
+      <h3>Mouse</h3>
       <ul>
         <li>GeneChip™ Mouse Gene 1.0 ST Array</li>
         <li>GeneChip™ Mouse Gene 1.1 ST Array</li>
@@ -87,7 +87,7 @@ export default function Help() {
         <li>Mouse Exon 1.0 ST Array</li>
       </ul>
 
-      <h2>Analysis</h2>
+      <h3>Analysis</h3>
       <p>
         Once the files are uploaded, choose groups for each sample. At least 2 groups must be
         created. The control group should be entered last. For example:
@@ -107,19 +107,19 @@ export default function Help() {
         titled <a href="#qualityControl"><b>Sample Quality Control.</b></a>
       </p>
 
-      <h2 id="manualGroups">Manually Add Groups and Batches:</h2>
+      <h4 id="manualGroups">Manually Add Groups and Batches:</h4>
       <video preload="metadata" controls>
         <source src="/assets/img/manualGroup.mp4" type="video/mp4" />
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Upload Groups and Batches:</h2>
+      <h4>Upload Groups and Batches:</h4>
       <video preload="metadata" controls>
         <source src="/assets/img/csvGroup.mp4" type="video/mp4" />
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Array Probe Quality Control:</h2>
+      <h4>Array Probe Quality Control:</h4>
       <p>
         Two plots, NUSE and RLE, display quality control metrics for the microarray probes. Plots
         are created with the oligo package:
@@ -154,7 +154,7 @@ export default function Help() {
         </a>
       </p>
 
-      <h2>Normalization</h2>
+      <h3>Normalization</h3>
       <p>
         Each sample is normalized to correct for technical artifacts using the Robust Multichip
         Averaging (RMA) method described in (Irizarry et al., 2003). Optional cyclic loess is also
@@ -206,13 +206,13 @@ export default function Help() {
         </a>
       </p>
 
-      <h2 id="qualityControl">Sample Quality Control</h2>
+      <h3 id="qualityControl">Sample Quality Control</h3>
       <p>
         Two plots, the sample similarity heatmap and 3D PCA, provide information about the quality
         of replicates in the groups.
       </p>
 
-      <h2>3D PCA:</h2>
+      <h4>3D PCA:</h4>
       <p>
         In general, samples in the same group should cluster together, and groups of samples
         should cluster separately from other groups. If batch effects are present, re-run the
@@ -241,13 +241,13 @@ export default function Help() {
         implemented.
       </p>
 
-      <h2>Sample Similarity Heatmap:</h2>
+      <h4>Sample Similarity Heatmap:</h4>
       <video preload="metadata" controls>
         <source src="/assets/img/heatmap.mp4" type="video/mp4" />
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Differential Gene Expression</h2>
+      <h3>Differential Gene Expression</h3>
       <p>
         The DEG-Enrichments Results tab displays differentially expressed genes between groups.
         MAAPster runs analysis in the background with the limma package. Linear modeling is
@@ -265,7 +265,7 @@ export default function Help() {
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Pathway Analysis</h2>
+      <h3>Pathway Analysis</h3>
       <p>
         The top 500 significantly upregulated and top 500 significantly downregulated genes are
         extracted for pathway analysis (significance is determined as unadjusted p-value &lt;
@@ -275,7 +275,7 @@ export default function Help() {
         </a>.
       </p>
 
-      <h2>Gene Heatmaps:</h2>
+      <h4>Gene Heatmaps:</h4>
       <p>
         Click on a pathway to generate a heatmap for the genes in the pathway. The heatmap will
         include groups selected in the contrast and will display scaled normalized gene expression
@@ -286,7 +286,7 @@ export default function Help() {
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Single-sample GSEA (ssGSEA)</h2>
+      <h3>Single-sample GSEA (ssGSEA)</h3>
       <p>
         ssGSEA is performed using the gsva package as previously described (Hanzelmann et al.,
         2013). Pathway enrichment scores are then analyzed to determine fold changes and p-values
@@ -307,10 +307,10 @@ export default function Help() {
         Sorry, your browser doesn&apos;t support embedded videos.
       </video>
 
-      <h2>Download Results</h2>
+      <h3>Download Results</h3>
       <p>All tables and plots generated may be downloaded.</p>
 
-      <h2>References</h2>
+      <h3>References</h3>
       <ul>
         <li>
           Ballman, K. V., Grill, D. E., Oberg, A. L., &amp; Therneau, T. M. (2004). Faster cyclic


### PR DESCRIPTION
[NCIATWP-9992](https://tracker.nci.nih.gov/browse/NCIATWP-9992)

## Summary
- Adjusted all heading levels on the Help page to match the original Prod hierarchy (h2/h3/h4 instead of h1/h2)
- Added h4 styling in globals.css (black text, no border-bottom, smaller font)
- Increased h1-h3 font sizes for better readability
- Reduced top padding on content-board and removed first h2 top margin