### PR TITLE
redirect to point to our fork of mpstr

### DIFF
--- a/server/setup/setup.R
+++ b/server/setup/setup.R
@@ -32,7 +32,7 @@ BiocManager::install(
     "clariomdhumantranscriptcluster.db"))
 
 # Install mpstr AFTER Bioconductor (mpstr depends on packages above)
-remotes::install_github("CCBR/MicroArrayPipeline/mpstr")
+remotes::install_github("CBIIT/MAAPster/mpstr")
 if (!requireNamespace("mpstr", quietly = TRUE)) stop("mpstr package failed to install")
 
 # Use latest version from https://github.com/CCBR/l2p


### PR DESCRIPTION
[NCIATWP-10074](https://tracker.nci.nih.gov/browse/NCIATWP-10074)

- redirect to point to our fork of mpstr
- Change be found in the commit below
https://github.com/CBIIT/MAAPster/commit/5021f3b61d70c57014d908a58d8c7a523e5c7d16 