### PR TITLE
NCIATWP-10249 - wrong GSM selection and stale table state in Manage Groups

### DIFF
--- a/client-next/src/app/analysis/page.tsx
+++ b/client-next/src/app/analysis/page.tsx
@@ -536,7 +536,7 @@ export default function Analysis() {
             {store.activeTab === "gsm" && (
               <>
                 {loadError && <p style={{ color: "#b22222", fontSize: "1.1rem", margin: "1rem" }}>{loadError}</p>}
-                {(!loadError || store.dataLoaded) && <GSMData />}
+                {(!loadError || store.dataLoaded) && <GSMData key={store.projectId} />}
               </>
             )}
 

--- a/client-next/src/components/DataBox/GSMData.tsx
+++ b/client-next/src/components/DataBox/GSMData.tsx
@@ -75,15 +75,15 @@ const PAGE_SIZE_OPTIONS = [10, 15, 25, 50, 100, 200];
 export default function GSMData() {
   const store = useAnalysisStore();
   const { dataList, dataLoaded } = store;
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const [lastToggled, setLastToggled] = useState<number | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [lastToggled, setLastToggled] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [sortKey, setSortKey] = useState<string>("gsm");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [searchText, setSearchText] = useState("");
   const [pageSize, setPageSize] = useState(25);
   const [currentPage, setCurrentPage] = useState(1);
-  const allSelected = dataList.length > 0 && selected.size === dataList.length;
+  const allSelected = dataList.length > 0 && dataList.every((s) => selected.has(s.gsm));
   const someSelected = selected.size > 0 && !allSelected;
 
   const headerCheckboxRef = useCallback((el: HTMLInputElement | null) => {
@@ -95,18 +95,18 @@ export default function GSMData() {
     if (allSelected) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(dataList.map((_, i) => i)));
+      setSelected(new Set(dataList.map((s) => s.gsm)));
     }
   }
 
-  function toggleRow(index: number) {
-    setLastToggled(index);
+  function toggleRow(gsm: string) {
+    setLastToggled(gsm);
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
+      if (next.has(gsm)) {
+        next.delete(gsm);
       } else {
-        next.add(index);
+        next.add(gsm);
       }
       return next;
     });
@@ -259,16 +259,16 @@ export default function GSMData() {
           </thead>
           <tbody>
             {pagedData.map((sample, i) => {
-              const globalIdx = startIdx + i;
+              const rowKey = sample.gsm || String(startIdx + i);
               return (
-              <tr key={sample.gsm || globalIdx}>
+              <tr key={rowKey}>
                 <td>
                   <input
-                    key={lastToggled === globalIdx && selected.has(globalIdx) ? `${globalIdx}-pulse` : `${globalIdx}`}
-                    className={lastToggled === globalIdx && selected.has(globalIdx) ? "checkbox-pulse" : ""}
+                    key={lastToggled === sample.gsm && selected.has(sample.gsm) ? `${sample.gsm}-pulse` : sample.gsm}
+                    className={lastToggled === sample.gsm && selected.has(sample.gsm) ? "checkbox-pulse" : ""}
                     type="checkbox"
-                    checked={selected.has(globalIdx)}
-                    onChange={() => toggleRow(globalIdx)}
+                    checked={selected.has(sample.gsm)}
+                    onChange={() => toggleRow(sample.gsm)}
                     aria-label={`Select ${sample.gsm}`}
                   />
                 </td>
@@ -287,7 +287,7 @@ export default function GSMData() {
       <GroupBatchModal
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
-        selectedIndices={Array.from(selected)}
+        selectedGsms={Array.from(selected)}
         onClearSelection={() => { setSelected(new Set()); setLastToggled(null); }}
       />
     </div>

--- a/client-next/src/components/DataBox/GroupBatchModal.tsx
+++ b/client-next/src/components/DataBox/GroupBatchModal.tsx
@@ -10,14 +10,14 @@ type Mode = "group" | "batch" | "upload";
 interface GroupBatchModalProps {
   visible: boolean;
   onClose: () => void;
-  selectedIndices: number[];
+  selectedGsms: string[];
   onClearSelection: () => void;
 }
 
 export default function GroupBatchModal({
   visible,
   onClose,
-  selectedIndices,
+  selectedGsms,
   onClearSelection,
 }: GroupBatchModalProps) {
   const store = useAnalysisStore();
@@ -51,8 +51,6 @@ export default function GroupBatchModal({
     return { groupMap: gMap, batchMap: bMap };
   }, [store.dataList]);
 
-  const selectedGsms = selectedIndices.map((i) => store.dataList[i]?.gsm).filter(Boolean);
-
   function handleAdd() {
     const trimmed = name.trim();
     if (!trimmed) {
@@ -63,15 +61,18 @@ export default function GroupBatchModal({
       setMessage("The group name only allows letters, numbers, and one underscore (cannot be placed after a number). Must start with a letter. Valid Group Name Example: RNA_1");
       return;
     }
-    if (selectedIndices.length < 2) {
+    if (selectedGsms.length < 2) {
       setMessage("Select at least 2 GSM to add a group");
       return;
     }
 
+    const gsmSet = new Set(selectedGsms);
+    const indices = store.dataList.map((s, i) => (gsmSet.has(s.gsm) ? i : -1)).filter((i) => i !== -1);
+
     if (mode === "group") {
-      store.assignGroup(selectedIndices, trimmed);
+      store.assignGroup(indices, trimmed);
     } else {
-      store.assignBatch(selectedIndices, trimmed);
+      store.assignBatch(indices, trimmed);
     }
 
     setMessage("");


### PR DESCRIPTION
[NCIATWP-10249](https://tracker.nci.nih.gov/browse/NCIATWP-10249)

# Summary
Selection in the GSM Data table was tracked by row position in the sorted/filtered view rather than by sample identity, causing the Manage Groups popup to show the wrong samples. Resetting and loading a new dataset also left stale table state behind because the component's local state survived `store.reset()`.

- Row selection stored indices into `sortedData` (the filtered/sorted view) but the modal looked them up against `store.dataList` (the original array) — mismatched when any sort or filter was active
- CEL file uploads were affected even without an explicit filter because the default alphabetical sort differs from the server's upload order (`T1623` sorts before `TI6`)
- After Reset, checkbox selections, search text, sort order, page number, and page size all persisted because `GSMData` stays mounted and only returns an early message when `!dataLoaded`
- Fixed selection tracking by storing GSM IDs instead of row positions; indices are derived from GSM IDs only at the point of calling store actions
- Fixed stale state by keying `GSMData` to `store.projectId`, which changes on every `store.reset()`, causing a full remount with fresh defaults

# Test Plan

-  Load GSE22529, filter by "Chronic", select rows, open Manage Groups — popup should show the correct GSM IDs matching what was checked
-  Upload CEL files, select two visible rows, open Manage Groups — popup should show those exact files
-  Load GSE81, select rows 2/3/5/7, click Reset, load GSE22529 — no rows pre-selected, search bar empty, sort and page at defaults