### PR TITLE
NCIATWP-10316 - Fix the Include Chip(s) field so it accepts typed input

### DIFF
--- a/client-next/src/app/analysis/page.tsx
+++ b/client-next/src/app/analysis/page.tsx
@@ -300,7 +300,7 @@ export default function Analysis() {
                   placeholder="<All Chips>"
                   value={store.loadChip ?? ""}
                   disabled={store.dataLoaded || store.multichip}
-                  onChange={(e) => store.setChip(e.target.value.toUpperCase())}
+                  onChange={(e) => store.setLoadChip(e.target.value.toUpperCase())}
                 />
 
                 <button className={`btn btn-nci-primary w-100 mt-2${geoMutation.isPending ? " btn-loading" : ""}`} onClick={handleLoadGEO} disabled={isLoading || store.dataLoaded || store.fileList.length > 0}>

--- a/client-next/src/stores/analysisStore.ts
+++ b/client-next/src/stores/analysisStore.ts
@@ -131,6 +131,7 @@ export interface AnalysisActions {
   setAnalysisType: (type: AnalysisType) => void;
   setAccessionCode: (code: string) => void;
   setChip: (chip: string) => void;
+  setLoadChip: (loadChip: string) => void;
   generateProjectId: () => void;
   setInit: (init: boolean) => void;
 
@@ -305,6 +306,7 @@ export const useAnalysisStore = create<AnalysisState & AnalysisActions>((set, ge
   setAnalysisType: (type) => set({ analysisType: type }),
   setAccessionCode: (code) => set({ accessionCode: code }),
   setChip: (chip) => set({ chip }),
+  setLoadChip: (loadChip) => set({ loadChip }),
   generateProjectId: () => set({ projectId: generateId() }),
   setInit: (init) => set({ init }),
 


### PR DESCRIPTION
[NCIATWP-10316](https://tracker.nci.nih.gov/browse/NCIATWP-10316)

The "Include Chip(s)" field on the Analysis page could be clicked but would not accept any typed input. Its change handler was updating the wrong piece of state, so keystrokes never reached the field's value. Typing now works and the entered chip is used when loading GEO data.
  
- Added a setLoadChip action to the analysis store and pointed the Include Chip(s) input at it, so typed input updates the field that the Load request actually uses
- Preserved the existing behavior of upper-casing the entered value and disabling the field after data loads