### PR TITLE
Add Load EFS Data workflow to sync reference data from S3 to EFS

### DIFF
--- a/.github/aws/data-import.yml
+++ b/.github/aws/data-import.yml
@@ -1,0 +1,53 @@
+family: "${ECS_DATA_IMPORT_TASK}"
+networkMode: awsvpc
+cpu: "512"
+memory: "1024"
+executionRoleArn: "${ROLE_ARN}"
+taskRoleArn: "${ROLE_ARN}"
+requiresCompatibilities:
+  - FARGATE
+runtimePlatform:
+  cpuArchitecture: X86_64
+  operatingSystemFamily: LINUX
+volumes:
+  - name: data
+    efsVolumeConfiguration:
+      fileSystemId: "${EFS_FILESYSTEM_ID}"
+      authorizationConfig:
+        accessPointId: "${EFS_ACCESS_POINT_ID}"
+        iam: ENABLED
+      transitEncryption: ENABLED
+containerDefinitions:
+  - name: data-import
+    image: public.ecr.aws/aws-cli/aws-cli:latest
+    essential: true
+    entryPoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        aws s3 sync "s3://${DATA_BUCKET}/microarray/data/" /data/data/
+        && echo '--- /data/data after sync ---'
+        && ls -la /data/data
+    mountPoints:
+      - sourceVolume: data
+        containerPath: "/data"
+        readOnly: false
+    logConfiguration:
+      logDriver: awslogs
+      options:
+        awslogs-group: "/analysistools/${TIER}/${APP}/data-import"
+        awslogs-region: "${AWS_REGION}"
+        awslogs-stream-prefix: data-import
+        awslogs-create-group: "true"
+tags:
+  - key: Project
+    value: "${APP}"
+  - key: ApplicationName
+    value: "${APP}"
+  - key: ResourceName
+    value: "${TIER}-${APP}-data-import-ecs-task"
+  - key: EnvironmentTier
+    value: "${TIER_UPPER}"
+  - key: ResourceFunction
+    value: compute
+  - key: Creator
+    value: CDK

--- a/.github/workflows/deploy-efs-data.yml
+++ b/.github/workflows/deploy-efs-data.yml
@@ -1,0 +1,105 @@
+name: Load EFS Data
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Deploy environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - qa
+          - stage
+          - prod
+
+jobs:
+  load-efs-data:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.tier }}
+    env:
+      APP: microarray
+      AWS_REGION: us-east-1
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      TIER: ${{ inputs.tier }}
+      DATA_BUCKET: ${{ vars.DATA_BUCKET }}
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+      PARAMETER_PATH: /analysistools/${{ inputs.tier }}/microarray
+      ECS_DATA_IMPORT_TASK: ${{ inputs.tier }}-microarray-data-import
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ env.CICD_ROLE_ARN }}
+          role-session-name: ${{ env.TIER }}-microarray-efs-data-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 3600
+
+      - name: Set derived variables
+        run: echo "TIER_UPPER=$(echo '${{ inputs.tier }}' | tr '[:lower:]' '[:upper:]')" >> "$GITHUB_ENV"
+
+      - name: Retrieve infra values from SSM
+        run: |
+          PARAMS=$(aws ssm get-parameters-by-path --path "$PARAMETER_PATH" --recursive --output json)
+          get() { echo "$PARAMS" | jq -r --arg n "$PARAMETER_PATH/$1" '.Parameters[] | select(.Name==$n) | .Value'; }
+          {
+            echo "ROLE_ARN=$(get role_arn)"
+            echo "SUBNET_IDS=$(get subnet_ids)"
+            echo "SECURITY_GROUP_IDS=$(get security_group_ids)"
+            echo "ECS_CLUSTER=$(get ecs_cluster)"
+            echo "EFS_FILESYSTEM_ID=$(get efs_filesystem_id)"
+            echo "EFS_ACCESS_POINT_ID=$(get efs_access_point_id)"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate required values
+        run: |
+          test -n "$DATA_BUCKET" || { echo "::error::vars.DATA_BUCKET is not set for the '$TIER' environment"; exit 1; }
+          missing=0
+          for v in ROLE_ARN SUBNET_IDS SECURITY_GROUP_IDS ECS_CLUSTER EFS_FILESYSTEM_ID EFS_ACCESS_POINT_ID; do
+            if [ -z "${!v}" ]; then echo "::error::$v missing from SSM under $PARAMETER_PATH — has deploy-infrastructure run for '$TIER'?"; missing=1; fi
+          done
+          test "$missing" = "0"
+
+      - name: Render data-import task definition
+        run: |
+          mkdir -p ecs-tasks
+          envsubst < .github/aws/data-import.yml > ecs-tasks/data-import.yml
+          echo "----- rendered task definition -----"
+          cat ecs-tasks/data-import.yml
+
+      - name: Register data-import task definition
+        run: aws ecs register-task-definition --cli-input-yaml file://ecs-tasks/data-import.yml
+
+      - name: Run data-import task
+        id: run
+        run: |
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$ECS_CLUSTER" \
+            --count 1 \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_IDS],securityGroups=[$SECURITY_GROUP_IDS],assignPublicIp=DISABLED}" \
+            --task-definition "$ECS_DATA_IMPORT_TASK" \
+            --query 'tasks[0].taskArn' --output text)
+          test -n "$TASK_ARN" && test "$TASK_ARN" != "None" || { echo "::error::run-task did not return a task ARN"; exit 1; }
+          echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "Started $TASK_ARN"
+
+      - name: Wait for task to stop
+        run: aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "${{ steps.run.outputs.task_arn }}"
+
+      - name: Check exit code
+        run: |
+          DESC=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks "${{ steps.run.outputs.task_arn }}" --output json)
+          echo "$DESC" | jq -r '.tasks[0] | "stoppedReason: \(.stoppedReason // "n/a")"'
+          CODE=$(echo "$DESC" | jq -r '.tasks[0].containers[] | select(.name=="data-import") | .exitCode // "null"')
+          echo "data-import container exit code: $CODE"
+          test "$CODE" = "0" || { echo "::error::data-import task did not exit cleanly (exit code: $CODE) — check CloudWatch group /analysistools/$TIER/microarray/data-import"; exit 1; }
+          echo "EFS data load completed successfully."


### PR DESCRIPTION
Adds the **Load EFS Data** GitHub Actions workflow that syncs the MicroArray reference data (GMT files) from S3 onto the tier's EFS, automating the manual SSH `aws s3 sync` procedure in deployment-runbook §5.

## How it works
- `workflow_dispatch` with a tier choice (dev/qa/stage/prod).
- Resolves all infra inputs (role, subnets, security groups, cluster, EFS filesystem + access point) from SSM under `/analysistools/<tier>/microarray` — no new infra required.
- Renders a stock `aws-cli` Fargate task def and runs it in-VPC (`run-task`), since EFS is only reachable over NFS inside the VPC. The task mounts the EFS access point (uid/gid 1000) and runs `aws s3 sync s3://$DATA_BUCKET/microarray/data/ /data/data/`.
- Waits for the task to stop and asserts the container exited 0; sync output goes to CloudWatch `/analysistools/<tier>/microarray/data-import`.

## Changes
- `.github/workflows/deploy-efs-data.yml` — the Load EFS Data workflow.
- `.github/aws/data-import.yml` — the loader Fargate task definition.

## Prerequisite
- Per-environment `DATA_BUCKET` repository variable must be set (lower tiers → nonprod bucket, upper tiers → prod bucket). Request sent to the GH-admin team.