### PR TITLE
send logs to datadog

### DIFF
--- a/.github/aws/web.yml
+++ b/.github/aws/web.yml
@@ -102,29 +102,20 @@ containerDefinitions:
         containerPath: "/data"
         readOnly: false
     logConfiguration:
-      # TEMP (debug): awslogs captures the backend's startup stderr directly, which
-      # firelens loses on a fast crash. Revert to the awsfirelens/datadog block below
-      # once the crash is diagnosed.
-      logDriver: awslogs
+      logDriver: awsfirelens
       options:
-        awslogs-group: "/analysistools/${TIER}/${APP}/web"
-        awslogs-region: "${AWS_REGION}"
-        awslogs-stream-prefix: backend
-        awslogs-create-group: "true"
-      # logDriver: awsfirelens
-      # options:
-      #   Name: datadog
-      #   tls: "on"
-      #   tls.verify: "off"
-      #   dd_service: "${TIER}-${APP}-backend"
-      #   dd_source: "nodejs"
-      #   dd_tags: "project:${APP} tier:${TIER}"
-      #   provider: ecs
-      # secretOptions:
-      #   - name: Host
-      #     valueFrom: /analysistools/${TIER}/datadog/log_endpoint_host
-      #   - name: apikey
-      #     valueFrom: /analysistools/${TIER}/datadog/api_key
+        Name: datadog
+        tls: "on"
+        tls.verify: "off"
+        dd_service: "${TIER}-${APP}-backend"
+        dd_source: "nodejs"
+        dd_tags: "project:${APP} tier:${TIER}"
+        provider: ecs
+      secretOptions:
+        - name: Host
+          valueFrom: /analysistools/${TIER}/datadog/log_endpoint_host
+        - name: apikey
+          valueFrom: /analysistools/${TIER}/datadog/api_key
 tags:
   - key: Project
     value: "${APP}"


### PR DESCRIPTION
Debugging with cloudwatch is complete, revert changes and send logs to datadog again.